### PR TITLE
Added beetleDC as core

### DIFF
--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -12,6 +12,8 @@ from lutris import settings
 LIBRETRO_CORES = [
     ("4do (3DO)", "4do", "3DO"),
     ("atari800 (Atari 800/5200)", "atari800", "Atari 800/5200"),
+    ('beetleDC (Sega Dreamcast)', 'beetledc', 'Sega Dreamcast'),
+    ('beetleDC WinCE (Sega Dreamcast)', 'beetledc_wince', 'Sega Dreamcast'),
     ("BlastEm (Sega Genesis)", "blastem", "Sega Genesis"),
     ("blueMSX (MSX/MSX2/MSX2+)", "bluemsx", "MSX/MSX2/MSX2+"),
     ("Caprice32 (Amstrad CPC)", "cap32", "Amstrad CPC"),


### PR DESCRIPTION
The reicast core has been depreciated in RetroArch, and renamed/replaced by beetleDC. The reicast core should be depreciated/removed in a future version to keep parity with mainline RetroArch